### PR TITLE
Add issue template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ However, we have to take a moment to judge whether fitting to the project aim an
 
 > :warning: Did you find a security vulnerability? _Report directly to security@marp.app instead of opening a new issue._
 
-Currently, we don't have a default issue template. But to assist in finding the bug by committer rapidly, it is good to describe these:
+To assist in finding the bug by contributor rapidly, it is good to describe these:
 
 - Expected behavior and actual behavior
 - Necessary steps and resources to reproduce bug

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔍 Search existed issues from marp-team organization
+    url: https://github.com/search?q=org%3Amarp-team+is%3Aissue+
+    about: Search for similar issues before reporting your issue. It may be already reported and resolved.
+  - name: 🙅‍♀️ Please don't ask for support in GitHub Issue
+    url: https://github.com/marp-team/.github/blob/master/SUPPORT.md#question
+    about: GitHub Issue is for tracking problems occurred in our project and not for questions. Please follow SUPPORT.md.

--- a/ISSUE_TEMPLATE/create-new-issue.md
+++ b/ISSUE_TEMPLATE/create-new-issue.md
@@ -1,0 +1,7 @@
+---
+name: Create new issue
+about: Start creating new issue from here.
+---
+
+<!-- Please follow the contributing guideline both of Marp team common and repository-specific (if any). -->
+<!-- Don't forget to search existed issue from marp-team organization before creating new issue! -->


### PR DESCRIPTION
Added issue template to make clear that Marp team is not the customer support. 

[One-third of new issues in last 3 months](https://github.com/search?q=org%3Amarp-team+created%3A%3E2020-02-01+is%3Aissue&type=Issues) are actually just a question for supports. This fact means I spent a time about a month of open-source hours to answer them, and they prevented my work for improvement Marp ecosystem. According to our contributing guideline, the question should be asked in StackOverflow first.

`ISSUE_TEMPLATE/config.yml` adds new screen to select a type of issue before the editor screen. By adding description about question and link to SUPPORT.md, it may dissuade user from asking for supports.
